### PR TITLE
Fix exported hand poses

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -152,12 +152,16 @@ function init() {
 }
 
 function playClips(scene, clips) {
+  if (!scene.animations) return;
+
   const mixer = new THREE.AnimationMixer(scene);
 
   for (const clip of clips) {
     const animation = scene.animations.find(a => a.name === clip)
-    const action = mixer.clipAction(animation);
-    action.play();
+    if (animation) {
+      const action = mixer.clipAction(animation);
+      action.play();
+    }
   }
 
   mixer.update(0);

--- a/src/game.js
+++ b/src/game.js
@@ -151,6 +151,18 @@ function init() {
   scene.add(state.avatarGroup);
 }
 
+function playClips(scene, clips) {
+  const mixer = new THREE.AnimationMixer(scene);
+
+  for (const clip of clips) {
+    const animation = scene.animations.find(a => a.name === clip)
+    const action = mixer.clipAction(animation);
+    action.play();
+  }
+
+  mixer.update(0);
+}
+
 function initializeGltf(key, gltf) {
   if (idleEyes.hasIdleEyes(gltf)) {
     state.idleEyesMixers[key] = idleEyes.mixerForGltf(gltf);
@@ -177,6 +189,10 @@ function initializeGltf(key, gltf) {
       state.uvScrollMaps[key].push(uvScroll.initialStateForMesh(obj));
     }
   });
+
+  // TODO: We shouldn't have to do this, but the head models have their skeleton's right
+  // hand gripped by default, so we open both hands to ensure a consistent export.
+  playClips(gltf.scene, ["allOpen_L", "allOpen_R"]);
 }
 
 function saveInitialMorphTargetInfluences(node) {


### PR DESCRIPTION
This is a hacky fix for an issue with the source assets. The head models have their right hand gripped by default, and since we use that first skeleton as the exported skeleton, the right hand poses are reversed (the hand opens when you use the allGrip_R animation and vice versa).

This fix plays the "allOpen" animations on all of the loaded models so that they export correctly after mesh combination.