### PR TITLE
Fix eye and hand animations

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -5,6 +5,8 @@ import { combine } from "./mesh-combination";
 import debugConfig from "./debug-config";
 
 export function cloneSkeleton(skinnedMesh) {
+  skinnedMesh.skeleton.pose();
+
   const boneClones = new Map();
 
   for (const bone of skinnedMesh.skeleton.bones) {
@@ -117,14 +119,14 @@ function cloneIntoAvatar(avatarGroup) {
   return clonedScene;
 }
 
-export async function exportAvatar(avatarGroup, mixers) {
+export async function exportAvatar(avatarGroup) {
   // TODO: Re-evaluate whether we want to perform this step.
   // The intention (for now) is to make combination optional,
   // so that it is easy to debug and also if non-mergable meshes
   // are added, there's a workaround for them.
   const clone = cloneIntoAvatar(avatarGroup);
 
-  const avatar = await combine({ avatar: clone, mixers });
+  const avatar = await combine({ avatar: clone });
 
   if (debugConfig.debugGLTF) {
     console.log("avatar", avatar);

--- a/src/game.js
+++ b/src/game.js
@@ -193,10 +193,6 @@ function initializeGltf(key, gltf) {
       state.uvScrollMaps[key].push(uvScroll.initialStateForMesh(obj));
     }
   });
-
-  // TODO: We shouldn't have to do this, but the head models have their skeleton's right
-  // hand gripped by default, so we open both hands to ensure a consistent export.
-  playClips(gltf.scene, ["allOpen_L", "allOpen_R"]);
 }
 
 function saveInitialMorphTargetInfluences(node) {
@@ -356,8 +352,13 @@ function tick(time) {
     if (state.shouldExportAvatar) {
       state.shouldExportAvatar = false;
 
-      const mixers = Object.values(state.idleEyesMixers);
-      exportAvatar(state.avatarGroup, mixers).then(({ glb }) => {
+      // Reset all idle eyes animations before cloning or exporting the avatar
+      // so that we don't export it mid-blink.
+      Object.values(state.idleEyesMixers).forEach(mixer => {
+        mixer.setTime(0);
+      });
+
+      exportAvatar(state.avatarGroup).then(({ glb }) => {
         const blob = new Blob([glb], { type: "application/octet-stream" });
         const url = URL.createObjectURL(blob);
 

--- a/src/mesh-combination.js
+++ b/src/mesh-combination.js
@@ -49,7 +49,7 @@ function removeBakedMorphs(mesh, bakedMorphIndices) {
   });
 }
 
-export async function combine({ avatar, mixers }) {
+export async function combine({ avatar }) {
   const meshesToExclude = findChildrenByType(avatar, "SkinnedMesh").filter(
     (mesh) => mesh.material.transparent || hasHubsComponent(mesh, "uv-scroll")
   );
@@ -58,9 +58,6 @@ export async function combine({ avatar, mixers }) {
 
   const { textures, uvs } = await createTextureAtlas({ meshes });
   meshes.forEach((mesh) => remapUVs({ mesh, uvs: uvs.get(mesh) }));
-
-  //TODO: This can be moved elsewhere.
-  mixers.forEach((mixer) => mixer.stopAllAction());
 
   meshes.forEach((mesh) => removeBakedMorphs(mesh, bakeMorphs(mesh)));
 


### PR DESCRIPTION
This fix supersedes #17 with a better fix that also fixes eye movement animations. Prior to this fix it was possible to catch an avatar mid-blink and export it with the blinked morphs backed. There was also a problem with eye saccade movements sometimes being incorrectly offset on export, causing the iris to animate behind the sclera. This PR fixes those issues by resetting idle eye animations before cloning and exporting the avatar. It also resets the skeleton pose so, which fixes the hand pose issue that #17 fixed with a hack.