### PR TITLE
Recreate canvas and renderer when component remount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "hackweek-avatar-maker",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.34",
         "@fortawesome/free-solid-svg-icons": "^5.15.2",
@@ -13,7 +12,7 @@
         "react": "^17.0.1",
         "react-dom": "^17.0.1",
         "simplebar-react": "^2.3.0",
-        "three": "^0.125.2"
+        "three": "^0.141.0"
       },
       "devDependencies": {
         "@babel/core": "^7.12.10",
@@ -4514,9 +4513,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.125.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
-      "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.141.0.tgz",
+      "integrity": "sha512-JaSDAPWuk4RTzG5BYRQm8YZbERUxTfTDVouWgHMisS2to4E5fotMS9F2zPFNOIJyEFTTQDDKPpsgZVThKU3pXA=="
     },
     "node_modules/thunky": {
       "version": "1.1.0",
@@ -8809,9 +8808,9 @@
       }
     },
     "three": {
-      "version": "0.125.2",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.125.2.tgz",
-      "integrity": "sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA=="
+      "version": "0.141.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.141.0.tgz",
+      "integrity": "sha512-JaSDAPWuk4RTzG5BYRQm8YZbERUxTfTDVouWgHMisS2to4E5fotMS9F2zPFNOIJyEFTTQDDKPpsgZVThKU3pXA=="
     },
     "thunky": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "simplebar-react": "^2.3.0",
-    "three": "^0.125.2"
+    "three": "^0.141.0"
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,7 +2,6 @@ export default {
   avatarConfigChanged: "avatarConfigChanged",
   exportAvatar: "exportAvatar",
   resetView: "resetView",
-  reactIsLoaded: "reactIsLoaded",
   renderThumbnail: "renderThumbnail",
   thumbnailResult: "thumbnailResult",
   combinedMeshName: "CombinedMesh",

--- a/src/create-texture-atlas.js
+++ b/src/create-texture-atlas.js
@@ -84,7 +84,7 @@ export const createTextureAtlas = (function () {
         context.globalCompositeOperation = image ? "multiply" : "source-over";
 
         const colorClone = mesh.material.color.clone();
-        colorClone.convertLinearToGamma();
+        colorClone.convertLinearToSRGB();
 
         context.fillStyle = `#${colorClone.getHexString()}`;
         context.fillRect(min.x * ATLAS_SIZE_PX, min.y * ATLAS_SIZE_PX, tileSize, tileSize);

--- a/src/export.js
+++ b/src/export.js
@@ -53,12 +53,13 @@ export function combineHubsComponents(a, b) {
 export const exportGLTF = (function () {
   const exporter = new GLTFExporter();
   return function exportGLTF(object3D, { binary, animations }) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       exporter.parse(
         object3D,
         (gltf) => resolve({ gltf }),
         (error) => {
           console.error(error);
+          reject("Error exporting the avatar");
         },
         { binary, animations }
       );

--- a/src/export.js
+++ b/src/export.js
@@ -54,7 +54,14 @@ export const exportGLTF = (function () {
   const exporter = new GLTFExporter();
   return function exportGLTF(object3D, { binary, animations }) {
     return new Promise((resolve) => {
-      exporter.parse(object3D, (gltf) => resolve({ gltf }), { binary, animations });
+      exporter.parse(
+        object3D,
+        (gltf) => resolve({ gltf }),
+        (error) => {
+          console.error(error);
+        },
+        { binary, animations }
+      );
     });
   };
 })();

--- a/src/game.js
+++ b/src/game.js
@@ -57,9 +57,9 @@ const state = {
 };
 window.gameState = state;
 
-window.onresize = () => {
+window.addEventListener("resize", () => {
   state.shouldResize = true;
-};
+});
 document.addEventListener(constants.reactIsLoaded, () => {
   state.reactIsLoaded = true;
 });

--- a/src/game.js
+++ b/src/game.js
@@ -126,6 +126,7 @@ function init() {
 
   // TODO: Square this with react
   const renderer = new THREE.WebGLRenderer({ canvas: document.getElementById("scene"), antialias: true });
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
   renderer.physicallyCorrectLights = true;
   renderer.outputEncoding = THREE.sRGBEncoding;
   state.renderer = renderer;

--- a/src/game.js
+++ b/src/game.js
@@ -127,7 +127,7 @@ function init() {
   // TODO: Square this with react
   const renderer = new THREE.WebGLRenderer({ canvas: document.getElementById("scene"), antialias: true });
   renderer.physicallyCorrectLights = true;
-  renderer.gammaOutput = true;
+  renderer.outputEncoding = THREE.sRGBEncoding;
   state.renderer = renderer;
 
   state.clock = new THREE.Clock();

--- a/src/merge-geometry.js
+++ b/src/merge-geometry.js
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import { BufferGeometryUtils } from "three/examples/jsm/utils/BufferGeometryUtils";
+import { mergeBufferAttributes } from "three/examples/jsm/utils/BufferGeometryUtils";
 import constants from "./constants";
 import { GLTFCubicSplineInterpolant } from "./gltf-cubic-spline-interpolant";
 
@@ -39,7 +39,7 @@ function mergeSourceAttributes({ sourceAttributes }) {
 
   const destAttributes = {};
   Array.from(propertyNames.keys()).map((name) => {
-    destAttributes[name] = BufferGeometryUtils.mergeBufferAttributes(
+    destAttributes[name] = mergeBufferAttributes(
       allSourceAttributes.map((sourceAttributes) => sourceAttributes[name]).flat()
     );
   });
@@ -103,7 +103,7 @@ function mergeSourceMorphAttributes({
   propertyNames.forEach((propName) => {
     merged[propName] = [];
     Object.entries(destMorphTargetDictionary).forEach(([morphName, destMorphIndex]) => {
-      merged[propName][destMorphIndex] = BufferGeometryUtils.mergeBufferAttributes(unmerged[propName][destMorphIndex]);
+      merged[propName][destMorphIndex] = mergeBufferAttributes(unmerged[propName][destMorphIndex]);
     });
   });
 

--- a/src/mesh-combination.js
+++ b/src/mesh-combination.js
@@ -73,6 +73,21 @@ export async function combine({ avatar }) {
       delete geometry.attributes[`morphTarget${i}`];
       delete geometry.attributes[`morphNormal${i}`];
     }
+    // Computing tangents that was done in GLTFLoader in threejs 0.125.2 was removed in threejs r126 (https://github.com/mrdoob/three.js/pull/21186)
+    // The mergeSourceAttributes function will crash because it can't find the tangent attribute on some geometry.
+    // So putting back here the code that was executed in GLTFLoader 0.125.2:
+    const material = mesh.material;
+    if (
+      material.isMeshStandardMaterial === true &&
+      material.side === THREE.DoubleSide &&
+      geometry.getIndex() !== null &&
+      geometry.hasAttribute("position") === true &&
+      geometry.hasAttribute("normal") === true &&
+      geometry.hasAttribute("uv") === true &&
+      geometry.hasAttribute("tangent") === false
+    ) {
+      geometry.computeTangents();
+    }
   });
 
   const { source, dest } = mergeGeometry({ meshes });

--- a/src/react-components/AvatarEditorContainer.js
+++ b/src/react-components/AvatarEditorContainer.js
@@ -33,10 +33,13 @@ export function AvatarEditorContainer() {
   });
 
   // TODO: Save the wave to a static image, or actually do some interesting animation with it.
-  useEffect(async () => {
-    if (canvasUrl === null) {
-      setCanvasUrl(await generateWave());
+  useEffect(() => {
+    async function init() {
+      if (canvasUrl === null) {
+        setCanvasUrl(await generateWave());
+      }
     }
+    init();
   });
 
   function updateAvatarConfig(newConfig) {

--- a/src/react-components/AvatarEditorContainer.js
+++ b/src/react-components/AvatarEditorContainer.js
@@ -29,7 +29,6 @@ export function AvatarEditorContainer() {
     if (!thumbnailMode) {
       dispatch(constants.avatarConfigChanged, { avatarConfig: { ...avatarConfig, ...hoveredConfig } });
     }
-    dispatch(constants.reactIsLoaded);
   });
 
   // TODO: Save the wave to a static image, or actually do some interesting animation with it.

--- a/src/react-components/AvatarPreviewContainer.js
+++ b/src/react-components/AvatarPreviewContainer.js
@@ -1,12 +1,20 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 
 export function AvatarPreviewContainer({ thumbnailMode, canvasUrl }) {
+  const canvasRef = useRef(null);
+  useEffect(() => {
+    const canvasEl = canvasRef.current;
+    window.gameState.initRenderer(canvasEl);
+    return () => {
+      window.gameState.disposeRenderer();
+    };
+  }, [canvasRef]);
   return (
     <div id="sceneContainer">
       {!thumbnailMode && (
         <div className="waveContainer" style={{ backgroundImage: canvasUrl ? `url("${canvasUrl}")` : "none" }}></div>
       )}
-      <canvas id="scene"></canvas>
+      <canvas ref={canvasRef}></canvas>
     </div>
   );
 }

--- a/src/react-components/ToolbarContainer.js
+++ b/src/react-components/ToolbarContainer.js
@@ -35,8 +35,8 @@ export function ToolbarContainer({ onGLBUploaded, randomizeConfig }) {
         </button>
       </div>
       <div className="toolbarNotice">
-        <span>The 3D models used in this app are ©2020-2022 by individual <a href="https://www.mozilla.org" target="_blank" noreferrer>mozilla.org</a> contributors.
-          Content available under a <a href="https://www.mozilla.org/en-US/foundation/licensing/website-content/" target="_blank" noreferrer>Creative Commons license</a>.</span>
+        <span>The 3D models used in this app are ©2020-2022 by individual <a href="https://www.mozilla.org" target="_blank" rel="noreferrer">mozilla.org</a> contributors.
+          Content available under a <a href="https://www.mozilla.org/en-US/foundation/licensing/website-content/" target="_blank" rel="noreferrer">Creative Commons license</a>.</span>
       </div>
     </Toolbar>
   );


### PR DESCRIPTION
This PR is based on #37. Only the latest commit is new.

The changes are good if you want to use the `AvatarEditorContainer` component in a `Dialog` component that you can show and hide inside your react app.
The threejs renderer is created when the `AvatarPreviewContainer` mount and is disposed when the component unmount.

I created the functions `window.gameState.initRenderer` and `window.gameState.disposeRenderer` and refactored game.js to create only once the scene, and recreate the envmap and controls when the component is remounted.
Instead of setting `material.envMap` of each material, I just set it once with `scene.environment`.
I also added `sky.geometry.dispose();sky.material.dispose();` to properly clean up sky geometry and material.
I'm using `renderer.setAnimationLoop(tick)` instead of handling the loop with `window.requestAnimationFrame(tick);`.
This way the loop is stopped automatically when disposing the renderer, so we don't need to handle a state ourself.